### PR TITLE
fix arg type

### DIFF
--- a/vision/snippets/face_detection/faces.py
+++ b/vision/snippets/face_detection/faces.py
@@ -97,7 +97,7 @@ if __name__ == '__main__':
         '--out', dest='output', default='out.jpg',
         help='the name of the output file.')
     parser.add_argument(
-        '--max-results', dest='max_results', default=4,
+        '--max-results', dest='max_results', default=4, type=int,
         help='the max results of face detection.')
     args = parser.parse_args()
 


### PR DESCRIPTION
fix default arg type string to int

## Description

Fixes #8843

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
